### PR TITLE
feat: Parse station type remark

### DIFF
--- a/src/metar.pest
+++ b/src/metar.pest
@@ -1,4 +1,4 @@
-METAR = { station ~ observation_time ~ auto_kw? ~ wind ~ visibility ~ clouds ~ temp_dew ~ altimeter }
+METAR = { station ~ observation_time ~ auto_kw? ~ wind ~ visibility ~ clouds ~ temp_dew ~ altimeter ~ remarks? }
 
 station = { (ASCII_ALPHA_UPPER | ASCII_DIGIT){4} }
 observation_time = { ASCII_DIGIT{6} ~ "Z" }
@@ -23,6 +23,11 @@ temp_dew = ${ temp_measurement ~ "/" ~ temp_measurement }
 temp_measurement = @{ "M"? ~ ASCII_DIGIT{2} }
 
 altimeter = ${ "A" ~ ASCII_DIGIT{4} }
+
+remarks = { remarks_kw ~ remark* }
+remarks_kw = _{ "RMK" }
+remark = _{ remark_station_type }
+remark_station_type = { "AO1" | "AO2" }
 
 // Compass direction given as 3 digits.
 direction = { ASCII_DIGIT{3} }

--- a/src/metar.rs
+++ b/src/metar.rs
@@ -13,6 +13,8 @@ pub struct Metar {
     pub temp: i8,
     pub dewpoint: i8,
     pub altimeter: u16,
+
+    pub remarks: Option<Remarks>,
 }
 
 impl FromStr for Metar {
@@ -97,6 +99,11 @@ impl FromStr for CloudKind {
             _ => Err(()),
         }
     }
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct Remarks {
+    pub station_type: Option<String>,
 }
 
 #[cfg(test)]

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -22,6 +22,7 @@ fn basic_metar() {
         temp: 7,
         dewpoint: -2,
         altimeter: 3001,
+        remarks: None,
     };
 
     let received: Metar = raw.parse().expect("should be parseable");
@@ -82,4 +83,18 @@ fn clouds_all() {
     ]);
 
     assert_eq!(want_clouds, parsed.clouds);
+}
+
+#[test]
+fn remark_station_type_ao1() {
+    let parsed = parse_metar("KEWR 031951Z 01012KT 10SM CLR 08/M06 A3002 RMK AO1");
+
+    assert_eq!(Some("AO1".to_owned()), parsed.remarks.unwrap().station_type);
+}
+
+#[test]
+fn remark_station_type_ao2() {
+    let parsed = parse_metar("KEWR 031951Z 01012KT 10SM CLR 08/M06 A3002 RMK AO2");
+
+    assert_eq!(Some("AO2".to_owned()), parsed.remarks.unwrap().station_type);
 }


### PR DESCRIPTION
The station type is either `AO1` or `AO2` and indicates if the station differentiates between types of precipitation.
