### PR TITLE
feat: Parse temperature breakdown remark

### DIFF
--- a/src/metar.pest
+++ b/src/metar.pest
@@ -27,8 +27,12 @@ altimeter = ${ "A" ~ ASCII_DIGIT{4} }
 
 remarks = { remarks_kw ~ remark* }
 remarks_kw = _{ "RMK" }
-remark = _{ remark_station_type }
+remark = _{ remark_station_type | remark_temp_breakdown }
+
 remark_station_type = { "AO1" | "AO2" }
+
+remark_temp_breakdown = ${ "T" ~ breakdown_temp{2} }
+breakdown_temp = @{ ("1" | "0") ~ ASCII_DIGIT{3} }
 
 // Compass direction given as 3 digits.
 direction = { ASCII_DIGIT{3} }

--- a/src/metar.rs
+++ b/src/metar.rs
@@ -105,6 +105,13 @@ impl FromStr for CloudKind {
 #[derive(Debug, Default, PartialEq)]
 pub struct Remarks {
     pub station_type: Option<String>,
+    pub temp_breakdown: Option<TempBreakdown>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct TempBreakdown {
+    pub temp: f32,
+    pub dewpoint: f32,
 }
 
 #[cfg(test)]

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -106,3 +106,33 @@ fn remark_station_type_ao2() {
 
     assert_eq!(Some("AO2".to_owned()), parsed.remarks.unwrap().station_type);
 }
+
+#[test]
+fn remark_temp_detail() {
+    let parsed =
+        parse_metar("KRDU 041351Z 00000KT 10SM FEW150 SCT250 04/00 A3005 RMK AO2 T00440000");
+
+    let temp_breakdown = parsed
+        .remarks
+        .expect("should have remarks")
+        .temp_breakdown
+        .expect("should have temp breakdown");
+
+    assert_eq!(4.4, temp_breakdown.temp);
+    assert_eq!(0.0, temp_breakdown.dewpoint);
+}
+
+#[test]
+fn remark_temp_detail_negative() {
+    let parsed =
+        parse_metar("KRDU 041351Z 00000KT 10SM FEW150 SCT250 04/00 A3005 RMK AO2 T10441056");
+
+    let temp_breakdown = parsed
+        .remarks
+        .expect("should have remarks")
+        .temp_breakdown
+        .expect("should have temp breakdown");
+
+    assert_eq!(-4.4, temp_breakdown.temp);
+    assert_eq!(-5.6, temp_breakdown.dewpoint);
+}


### PR DESCRIPTION
If present, the temperature breakdown remark reports the temperature and dewpoint to tenths of a degree.

Closes #9
